### PR TITLE
Fix counter increment bug and CSS color typo

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,7 +5,8 @@ const resetBtn = document.getElementById("resetBtn");
 
 increaseBtn.addEventListener("click", function() {
   count++;
-  countElement.innerText = countt; // ❌ Bug: 'countt' is not defined
+  // Update the displayed count
+  countElement.innerText = count;
 });
 
 resetBtn.addEventListener("click", function() {

--- a/style.css
+++ b/style.css
@@ -26,5 +26,6 @@ button {
 }
 
 button:hover {
-  background-color: darkteal; /* ❌ Bug: 'darkteal' is not a valid color */
+  /* Use a valid darker teal color on hover */
+  background-color: darkcyan;
 }


### PR DESCRIPTION
## Summary
- fix bug referencing `countt` instead of `count`
- use valid hover color in CSS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68832c3b953483288ae697a69e01dcac